### PR TITLE
Changed to node-friendly raf module

### DIFF
--- a/lib/cycle.js
+++ b/lib/cycle.js
@@ -3,7 +3,7 @@
  */
 
 var assign = require('object-assign')
-var raf = require('component-raf')
+var raf = require('raf')
 
 /**
  * Export `cycle`

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/MatthewMueller/preact-socrates.git"
   },
   "dependencies": {
-    "component-raf": "^1.2.0",
+    "raf": "^3.2.0",
     "object-assign": "^4.0.1",
     "preact": "^4.1.1"
   },


### PR DESCRIPTION
This is the only change I needed to get your awesome [28kb example](https://github.com/matthewmueller/28kb-react-redux-routing) run [with server side rendering](https://github.com/slaskis/28kb-react-redux-routing/tree/isomorphic).

Thanks for these clarifying examples of simple react/redux implementations.
